### PR TITLE
Instrument uncaught exceptions in async functions.

### DIFF
--- a/plugins/zzz-last-plugin.js
+++ b/plugins/zzz-last-plugin.js
@@ -19,6 +19,10 @@ BOOMR.init({
       // Allow the platform code to disable auto-instrumenting console.error() logs
       // using the following property b/c they clutter things up in dev with some of our utilities.
       monitorConsole: (window.BOOMR.shouldMonitorConsoleErrors === false ? false : true), 
+      // Off by default. Turning it on so that "Uncaught (in promise) <some exception>" errors
+      // get wrapped and sent. Since async functions return a promise, this is basically looking
+      // for any uncaught exceptions in our async functions.
+      monitorRejections: true,
       onError: function(err) {
         // Send across some error fields. Most of the standardization and translation of them
         // is done in honeycomb.js or in the server side controller on the platform, but since


### PR DESCRIPTION
If an uncaught exception is thrown in a Promise (which is what an async function returns / is), they aren't automatically caught and put in a beacon by Boomerang by default. This turns that setting on.

### Test plan
Put `throw "test exception"` in an `async` function. The error won't be picked up by Boomerang and sent in a beacon to `HoneycombJsController` that propagates that info to Honeycomb. Turn this setting on an try again. The error should come through in `js.boomerang.error` and `js.boomerang.error_detail`